### PR TITLE
enhance: support more types when deducing, and fix bugs

### DIFF
--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -80,10 +80,17 @@ export function dumpStackState(stateFilepath: string, stackState: StackState) {
 export function dumpProject(project: config.Project) {
   const rootpath = project.rootpath;
 
-  const obj = project.deepCopy() as any;
-  delete obj.name;
-  delete obj.rootpath;
-  const content = yaml.dump(obj, { sortKeys: true });
+  // Remove the state field from the project before dumping it.
+  const proj = project.deepCopy();
+  proj.stacks.forEach((stack) => {
+    delete (stack as any).state;
+  });
+  // Remove the `name` and `rootpath` fields from the project before dumping it. They're loaded
+  // automatically when running the `pluto` command.
+  delete (proj as any).name;
+  delete (proj as any).rootpath;
+
+  const content = yaml.dump(proj, { sortKeys: true });
 
   const configFile = path.join(rootpath, PLUTO_PROJECT_CONFIG_PATH);
   fs.ensureFileSync(configFile);

--- a/components/deducers/python-pyright/src/code-extractor.ts
+++ b/components/deducers/python-pyright/src/code-extractor.ts
@@ -31,7 +31,6 @@ import * as TypeUtils from "./type-utils";
 import * as TypeConsts from "./type-consts";
 import * as ScopeUtils from "./scope-utils";
 import { SpecialNodeMap } from "./special-node-map";
-import { Value, ValueEvaluator } from "./value-evaluator";
 
 export interface CodeSegment {
   readonly node: ParseNode;
@@ -158,9 +157,10 @@ export class CodeExtractor {
       case ParseNodeType.List:
         segment = this.extractTupleOrListWithDependencies(node, sourceFile);
         break;
-      default:
+      default: {
         const nodeText = TextUtils.getTextOfNode(node, sourceFile);
         throw new Error(`Unsupported node type: ${node.nodeType}, text: \`${nodeText}\``);
+      }
     }
     return segment;
   }

--- a/components/deducers/python-pyright/src/index.ts
+++ b/components/deducers/python-pyright/src/index.ts
@@ -96,11 +96,7 @@ export default class PyrightDeducer extends core.Deducer {
 
     this.tracker = new ResourceObjectTracker(this.typeEvaluator, this.sepcialNodeMap);
     this.valueEvaluator = new ValueEvaluator(this.typeEvaluator);
-    this.extractor = new CodeExtractor(
-      this.typeEvaluator,
-      this.sepcialNodeMap,
-      this.valueEvaluator
-    );
+    this.extractor = new CodeExtractor(this.typeEvaluator, this.sepcialNodeMap);
 
     this.buildConstructedResources(constructNodes, sourceFile);
     this.buildRelationshipsFromInfraApis(infraApiNodes, sourceFile);

--- a/components/deducers/python-pyright/src/index.ts
+++ b/components/deducers/python-pyright/src/index.ts
@@ -373,11 +373,26 @@ export default class PyrightDeducer extends core.Deducer {
 
   private prepareDependencies(closures: arch.Closure[]) {
     for (const closure of closures) {
+      const destBaseDir = path.resolve(closure.path, "site-packages");
+      fs.ensureDirSync(destBaseDir);
+
       const closureFile = path.resolve(closure.path, "__init__.py");
       const pkgPaths = this.importFinder!.getDependentModules(closureFile);
       pkgPaths.forEach((pkgPath) => {
-        const dest = path.resolve(closure.path, path.basename(pkgPath));
+        const pkgName = path.basename(pkgPath);
+        const dest = path.resolve(destBaseDir, pkgName);
         fs.copySync(pkgPath, dest);
+
+        // Copy the .dist-info directory if it exists.
+        const prefix = pkgName.replace(/\.py$/g, ""); // The python module may just be a python file.
+        const distInforDirnames = fs.readdirSync(path.dirname(pkgPath)).filter((dirname) => {
+          return new RegExp(`^${prefix}-(\\d+(\\.\\d+)*?)\\.dist-info$`).test(dirname);
+        });
+        distInforDirnames.forEach((distInfoDirname) => {
+          const distInfoDir = path.resolve(path.dirname(pkgPath), distInfoDirname);
+          const dest = path.resolve(destBaseDir, distInfoDirname);
+          fs.copySync(distInfoDir, dest);
+        });
       });
     }
   }

--- a/components/deducers/python-pyright/src/scope-utils.ts
+++ b/components/deducers/python-pyright/src/scope-utils.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert";
+import { Scope } from "pyright-internal/dist/analyzer/scope";
+import { Symbol } from "pyright-internal/dist/analyzer/symbol";
 import * as ScopeUtils from "pyright-internal/dist/analyzer/scopeUtils";
 import { SourceFile } from "pyright-internal/dist/analyzer/sourceFile";
 import { CallNode } from "pyright-internal/dist/parser/parseNodes";
@@ -9,6 +11,14 @@ export function inGlobalScope(node: CallNode, sourceFile: SourceFile): boolean {
   assert(parseTree, "No parse tree found in source file.");
   const globalScope = ScopeUtils.getScopeForNode(parseTree!);
   return scope === globalScope;
+}
+
+export function getScopeForSymbol(symbol: Symbol): Scope | undefined {
+  const decls = symbol.getDeclarations();
+  if (decls.length === 0) {
+    return undefined;
+  }
+  return ScopeUtils.getScopeForNode(decls[0].node);
 }
 
 export const isScopeContainedWithin = ScopeUtils.isScopeContainedWithin;

--- a/components/deducers/python-pyright/src/scope-utils.ts
+++ b/components/deducers/python-pyright/src/scope-utils.ts
@@ -13,6 +13,7 @@ export function inGlobalScope(node: CallNode, sourceFile: SourceFile): boolean {
   return scope === globalScope;
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function getScopeForSymbol(symbol: Symbol): Scope | undefined {
   const decls = symbol.getDeclarations();
   if (decls.length === 0) {

--- a/components/deducers/python-pyright/src/test/code-extractor.test.ts
+++ b/components/deducers/python-pyright/src/test/code-extractor.test.ts
@@ -74,7 +74,7 @@ function createTools(program: Program, sourceFile: SourceFile) {
   const specialNodeMap = TestUtils.getSpecialNodeMap(program, sourceFile);
   const tracker = new ResourceObjectTracker(program.evaluator!, specialNodeMap);
   const valueEvaluator = new ValueEvaluator(program.evaluator!);
-  const extractor = new CodeExtractor(program.evaluator!, specialNodeMap, valueEvaluator);
+  const extractor = new CodeExtractor(program.evaluator!, specialNodeMap);
   return { specialNodeMap, tracker, valueEvaluator, extractor };
 }
 

--- a/components/deducers/python-pyright/src/test/samples/code_extractor_valid.py
+++ b/components/deducers/python-pyright/src/test/samples/code_extractor_valid.py
@@ -11,6 +11,24 @@ from pluto_client import (
     FunctionOptions,
 )
 from pluto_client.router import HttpResponse
+from pluto_client.sagemaker import SageMaker, SageMakerOptions
+
+# test case for dict argument
+sagemaker = SageMaker(
+    "sagemaker",
+    "image_uri",
+    SageMakerOptions(
+        envs={
+            "key1": 1,
+            "key2": "str",
+            "key3": True,
+            "key4": None,
+            "key5": [1, 2, 3],
+            "key6": {"key": "value"},
+            "key7": (1, 2, 3),
+        }
+    ),
+)
 
 queueName = "test-queue"
 queue = pluto_client.Queue(queueName)  # resource object construction
@@ -48,6 +66,7 @@ var_from_call = func(1, lambda x: x, echo)
 
 
 def get_handler(req: HttpRequest) -> pluto_client_alias.HttpResponse:
+    sagemaker.endpoint_url()  # access captured property
     print(var_from_call)  # variable dependency
     func(1, echo, lambda x: x)  # nested function dependency
     name = req.query["name"] if "name" in req.query else "Anonym"

--- a/components/deducers/python-pyright/src/test/samples/value_evaluator_valid.py
+++ b/components/deducers/python-pyright/src/test/samples/value_evaluator_valid.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Dict, Literal
 
 
 @dataclass
@@ -56,3 +56,17 @@ instance, and the value evaluator can't deduce the data class instance, the test
 
 # data class value evaluation
 Model(base=Base("name", age=19), gender="male", nullable=null_1)
+
+# Dict
+{
+    "key1": 1,
+    "key2": "str13",
+    "key3": True,
+    "key4": None,
+    "key5": (1, 2, 3),
+    "key6": Base("name", 19),
+}
+{
+    "key1": {"key2": 1, "key3": "str14"},
+    "key4": {"key5": True},
+}

--- a/packages/pluto-infra/src/aws/common_top_adapter.py
+++ b/packages/pluto-infra/src/aws/common_top_adapter.py
@@ -9,8 +9,16 @@ child_directory = os.path.join(current_directory, f"child_{depth}")
 while os.path.exists(child_directory):
     print(f"Adding {child_directory} to the system path.")
     sys.path.append(child_directory)
+
+    site_pkgs_dir = os.path.join(child_directory, "site-packages")
+    if os.path.exists(site_pkgs_dir):
+        print(f"Adding {site_pkgs_dir} to the system path.")
+        sys.path.append(site_pkgs_dir)
+
     depth += 1
     child_directory = os.path.join(child_directory, f"child_{depth}")
+
+print("The system path is:", sys.path)
 
 
 def handler(*args, **kwargs):


### PR DESCRIPTION
<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 
re #146 
<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- CLI
- Pyright Deudcer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

- Fix a bug that the local variables within a class's member are incorrectly identified as needing extraction. This issue arises because the class node and its members are at the same scope level. We cannot confirm whether the variables within a class member are located within the class scope.
- Fix a bug in dumping the Pluto project configuration to a configuration file, where it incorrectly includes some information that should not be included, such as the `state` attribute of the stack.
- Add support for dictionaries, lists, and tuples types when extracting codes and evaluating values. This feature is useful when users need to add custom configurations to infrastructure resources, such as environment variables.
- Include the `dist-info` directory of Python packages when extracting dependencies.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
