### PR TITLE
fix(deducer): correct exportName setting for multiline export statements

### DIFF
--- a/.changeset/perfect-lamps-check.md
+++ b/.changeset/perfect-lamps-check.md
@@ -1,0 +1,30 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+fix(deducer): correct exportName setting for multiline export statements
+
+This commit addresses an issue where errors occur when setting the exportName for export statements that contain line breaks. The issue arises particularly when the export statement is a function call, lambda expression, or similar, and spans multiple lines.
+
+Previously, the strategy was to assign the last line of the statement to the exportName, which proved to be incorrect for multiline statements. This commit changes that approach to assign the entire statement to the exportName, if the statement spans multiple lines.
+
+Consider the following function call, where the second argument is the statement we want to export:
+
+```python
+router.all("/*", lambda *args, **kwargs: Mangum(return_fastapi_app(),
+                                                api_gateway_base_path="/dev")(*args, **kwargs), raw=True)
+```
+
+Before this fix, the assignment would look like this:
+
+```python
+lambda *args, **kwargs: Mangum(return_fastapi_app(),
+exportName                                                api_gateway_base_path="/dev")(*args, **kwargs)
+```
+
+After this fix, the assignment is as follows:
+
+```python
+exportName = lambda *args, **kwargs: Mangum(return_fastapi_app(),
+                                                api_gateway_base_path="/dev")(*args, **kwargs)
+```

--- a/components/deducers/python-pyright/src/index.ts
+++ b/components/deducers/python-pyright/src/index.ts
@@ -395,15 +395,6 @@ export default class PyrightDeducer extends core.Deducer {
   }
 }
 
-function addToStringAtLastLine(originalString: string, stringToAdd: string): string {
-  const lines = originalString.split("\n");
-  if (lines.length === 0) {
-    return stringToAdd;
-  }
-  lines[lines.length - 1] = stringToAdd + lines[lines.length - 1];
-  return lines.join("\n");
-}
-
 /**
  * Try to get the name of the variable the call node is assigned to.
  * @param callNode - The call node.
@@ -471,14 +462,7 @@ function extractAndStoreClosure(
   extractor: CodeExtractor
 ) {
   const codeSegment = extractor!.extractExpressionRecursively(argNode.valueExpression, sourceFile);
-
-  let closureText = CodeSegment.toString(codeSegment);
-  if (codeSegment.exportableName) {
-    closureText += `\n_default = ${codeSegment.exportableName}`;
-  } else {
-    closureText = addToStringAtLastLine(closureText, "_default = ");
-  }
-
+  const closureText = CodeSegment.toString(codeSegment, /* exportName */ "_default");
   const closureName = "fn_" + argNode.start.toString();
   const closureFile = path.resolve(closureBaseDir, closureName, "__init__.py");
   fs.ensureFileSync(closureFile);


### PR DESCRIPTION


<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

This commit addresses an issue where errors occur when setting the exportName for export statements that contain line breaks. The issue arises particularly when the export statement is a function call, lambda expression, or similar, and spans multiple lines.

Previously, the strategy was to assign the last line of the statement to the exportName, which proved to be incorrect for multiline statements. This commit changes that approach to assign the entire statement to the exportName, if the statement spans multiple lines.

Consider the following function call, where the second argument is the statement we want to export:
```python
router.all("/*", lambda *args, **kwargs: Mangum(return_fastapi_app(),
                                                api_gateway_base_path="/dev")(*args, **kwargs), raw=True)
```

Before this fix, the assignment would look like this:
```python
lambda *args, **kwargs: Mangum(return_fastapi_app(),
exportName                                                api_gateway_base_path="/dev")(*args, **kwargs)
```

After this fix, the assignment is as follows:
```python
exportName = lambda *args, **kwargs: Mangum(return_fastapi_app(),
                                                api_gateway_base_path="/dev")(*args, **kwargs)
```

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
