### PR TITLE
feat(generator): default to from-resource's ID when to-resources is emtpy

### DIFF
--- a/.changeset/tidy-jobs-sing.md
+++ b/.changeset/tidy-jobs-sing.md
@@ -1,0 +1,8 @@
+---
+"@plutolang/graphviz-generator": patch
+---
+
+feat(generator): default to from-resource's ID when to-resources is empty
+
+- The generator will now use the 'from-resource' ID as a fallback when the 'to-resources' field is left empty.
+- Also, changed the output format from SVG to PNG.

--- a/components/generators/graphviz/src/generator.ts
+++ b/components/generators/graphviz/src/generator.ts
@@ -18,8 +18,8 @@ export class GraphvizGenerator extends core.Generator {
     const dotFile = path.join(outdir, "arch.dot");
     writeToFile("", dotFile, dotText);
 
-    const svgFile = path.join(outdir, "arch.svg");
-    await toFile(dotText, svgFile, { format: "svg" });
+    const svgFile = path.join(outdir, "arch.png");
+    await toFile(dotText, svgFile, { format: "png" });
     return { entrypoint: svgFile };
   }
 }
@@ -41,7 +41,7 @@ function archToGraphviz(archRef: arch.Architecture): string {
         .join(",")
         .replace(/"/g, '\\"');
     const fromId = relat.from.id;
-    const toIds = relat.to.map((r) => r.id).join(",");
+    const toIds = relat.to.map((r) => r.id).join(",") || fromId;
     dotSource += `  ${fromId} -> ${toIds} [label="${label}",color="${color}"];\n`;
   }
   dotSource += "}";


### PR DESCRIPTION
- The generator will now use the 'from-resource' ID as a fallback when the 'to-resources' field is left empty.
- Also, changed the output format from SVG to PNG.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):
- generator
<!-- You can add the scope of this change here. -->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [x] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->
The output format of the generator has been changed from PNG to SVG.
#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
