### PR TITLE
feat(deducer): support more situations for resource constructor and infra api args

### DIFF
--- a/.changeset/pretty-spies-visit.md
+++ b/.changeset/pretty-spies-visit.md
@@ -1,0 +1,13 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+feat(deducer): support more situations for resource constructor and infra api args
+
+This update enhances the deducer module by allowing environment variables and variables to be passed to resource constructors and infra API arguments. Specifically, it now supports:
+
+- Direct literal values (e.g., `1`, `true`, `"hello"`).
+- Direct dataclass constructors (e.g., `Model(name="hello")` where `Model` is a dataclass).
+- Direct access to environment variables (e.g., `os.environ["key"]`, `os.environ.get("key", "default")`).
+- Variables (e.g., `var1`, `var2`), with the requirement that they are defined exactly once and assigned with the supported value types.
+- Tuples or dicts containing the supported types of values.

--- a/components/deducers/python-pyright/src/value-evaluator.ts
+++ b/components/deducers/python-pyright/src/value-evaluator.ts
@@ -1,87 +1,190 @@
 import { TypeEvaluator } from "pyright-internal/dist/analyzer/typeEvaluatorTypes";
-import { ExpressionNode, ParseNodeType } from "pyright-internal/dist/parser/parseNodes";
-import { ClassType, LiteralValue, TypeCategory } from "pyright-internal/dist/analyzer/types";
+import {
+  CallNode,
+  DictionaryNode,
+  ExpressionNode,
+  IndexNode,
+  NameNode,
+  ParseNodeType,
+  TupleNode,
+} from "pyright-internal/dist/parser/parseNodes";
+import {
+  ClassType,
+  LiteralValue as LiteralTypes,
+  TypeCategory,
+} from "pyright-internal/dist/analyzer/types";
 import * as TypeUtils from "./type-utils";
 
-type ValuePair = [Value, Value];
-
-export interface Value {
-  /**
-   * If the type is undefined, it means the value is a primitive, including boolean, integer,
-   * string, and float.
-   */
-  type?: string;
-
-  value?:
-    | LiteralValue
-    | Record<string, Value> /* dataclass */
-    | Array<Value> /* tuple */
-    | Array<ValuePair> /* dict */;
+export enum ValueType {
+  None = "none",
+  Literal = "literal",
+  DataClass = "dataclass",
+  Tuple = "tuple",
+  Dict = "dict",
+  EnvVarAccess = "envVarAccess",
 }
+
+interface ValueBase {
+  readonly valueType: ValueType;
+}
+
+interface NoneValue extends ValueBase {
+  readonly valueType: ValueType.None;
+}
+
+interface LiteralValue extends ValueBase {
+  readonly valueType: ValueType.Literal;
+  readonly value: LiteralTypes;
+}
+
+interface DataClassValue extends ValueBase {
+  readonly valueType: ValueType.DataClass;
+  readonly classType: string;
+  readonly value: Record<string, Value>;
+}
+
+interface TupleValue extends ValueBase {
+  readonly valueType: ValueType.Tuple;
+  readonly value: Value[];
+}
+
+interface DictValue extends ValueBase {
+  readonly valueType: ValueType.Dict;
+  readonly value: [Value, Value][];
+}
+
+interface EnvVarAccessValue extends ValueBase {
+  readonly valueType: ValueType.EnvVarAccess;
+  readonly envVarName: string;
+  readonly defaultEnvVarValue?: string;
+}
+
+export type Value =
+  | NoneValue
+  | LiteralValue
+  | DataClassValue
+  | TupleValue
+  | DictValue
+  | EnvVarAccessValue;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Value {
-  export function toString(value: Value, containModuleName: boolean = true): string {
-    if (value.type === undefined) {
-      // This is a primitive. We can directly return the JSON stringified value.
-      return JSON.stringify(value.value);
-    }
-
-    if (value.type === "types.NoneType") {
-      return "None";
-    }
-
-    switch (value.type) {
-      case "builtins.tuple": {
-        const values = value.value! as Value[];
-        return `(${values.map((v) => Value.toString(v)).join(", ")})`;
-      }
-      case "builtins.dict": {
-        const values = value.value! as ValuePair[];
-        const kvs = values.map(([k, v]) => `${Value.toString(k)}: ${Value.toString(v)}`);
-        return `{${kvs.join(", ")}}`;
-      }
-      default: {
-        // This is a data class object.
-        const type = containModuleName ? value.type : value.type.split(".").pop()!;
-        const values = value.value! as Record<string, Value>;
-        const params = Object.entries(values)
-          .map(([k, v]) => `${k}=${Value.toString(v)}`)
-          .join(", ");
-        return `${type}(${params})`;
-      }
-    }
+  interface ToStringOptions {
+    /**
+     * Whether to contain the module name in the output string. @default true
+     */
+    containModuleName?: boolean;
   }
 
-  export function toJson(value: Value): string {
-    if (value.type === undefined) {
-      // This is a primitive. We can directly return the JSON stringified value.
-      return JSON.stringify(value.value);
-    }
+  export function toString(value: Value, options: ToStringOptions = {}): string {
+    options.containModuleName = options.containModuleName ?? true;
 
-    if (value.type === "types.NoneType") {
-      return "null";
-    }
-
-    switch (value.type) {
-      case "builtins.tuple": {
-        const values = value.value! as Value[];
-        return `[${values.map((v) => Value.toJson(v)).join(", ")}]`;
-      }
-      case "builtins.dict": {
-        const values = value.value! as ValuePair[];
-        const kvs = values.map(([k, v]) => `${Value.toJson(k)}: ${Value.toJson(v)}`);
+    type toStringHandler<T extends Value> = (value: T) => string;
+    const toStringHandlers: Record<ValueType, toStringHandler<any>> = {
+      [ValueType.None]: () => {
+        return "None";
+      },
+      [ValueType.Literal]: (value: LiteralValue) => {
+        return JSON.stringify(value.value);
+      },
+      [ValueType.Tuple]: (value: TupleValue) => {
+        return `(${value.value.map((v) => Value.toString(v, options)).join(", ")})`;
+      },
+      [ValueType.Dict]: (value: DictValue) => {
+        const kvs = value.value.map(
+          ([k, v]) => `${Value.toString(k, options)}: ${Value.toString(v, options)}`
+        );
         return `{${kvs.join(", ")}}`;
-      }
-      default: {
-        // This is a data class object.
-        const values = value.value! as Record<string, Value>;
+      },
+      [ValueType.DataClass]: (value: DataClassValue) => {
+        const type = options?.containModuleName
+          ? value.classType
+          : value.classType.split(".").pop()!;
+        const params = Object.entries(value.value)
+          .map(([k, v]) => `${k}=${Value.toString(v, options)}`)
+          .join(", ");
+        return `${type}(${params})`;
+      },
+      [ValueType.EnvVarAccess]: (value: EnvVarAccessValue) => {
+        const envVarName = value.envVarName;
+        if (value.defaultEnvVarValue) {
+          return `os.environ.get("${envVarName}", "${value.defaultEnvVarValue}")`;
+        }
+        return `os.environ.get("${envVarName}")`;
+      },
+    };
+
+    const handler = toStringHandlers[value.valueType];
+    if (!handler) {
+      throw new Error(`Unable reach here: ${value}`);
+    }
+    return handler(value);
+  }
+
+  interface ToJsonOptions {
+    /**
+     * The target language to generate the JSON string. @default "python"
+     */
+    language?: "python" | "typescript";
+  }
+
+  export function toJson(value: Value, options: ToJsonOptions = {}): string {
+    options.language = options.language ?? "python";
+
+    type toJsonHandler<T extends Value> = (value: T) => string;
+    const toJsonHandlers: Record<ValueType, toJsonHandler<any>> = {
+      [ValueType.None]: () => {
+        return "null";
+      },
+      [ValueType.Literal]: (value: LiteralValue) => {
+        return JSON.stringify(value.value);
+      },
+      [ValueType.Tuple]: (value: TupleValue) => {
+        const values = value.value.map((v) => Value.toJson(v, options));
+        return `[${values.join(", ")}]`;
+      },
+      [ValueType.Dict]: (value: DictValue) => {
+        const kvs = value.value.map(
+          ([k, v]) => `${Value.toJson(k, options)}: ${Value.toJson(v, options)}`
+        );
+        return `{${kvs.join(", ")}}`;
+      },
+      [ValueType.DataClass]: (value: DataClassValue) => {
+        const values = value.value;
         const params = Object.entries(values)
-          .map(([k, v]) => `"${k}": ${Value.toJson(v)}`)
+          .map(([k, v]) => `"${k}": ${Value.toJson(v, options)}`)
           .join(", ");
         return `{${params}}`;
-      }
+      },
+      [ValueType.EnvVarAccess]: (value: EnvVarAccessValue) => {
+        const envVarName = value.envVarName;
+        if (value.defaultEnvVarValue) {
+          switch (options?.language) {
+            case "python":
+              return `os.environ.get("${envVarName}", "${value.defaultEnvVarValue}")`;
+            case "typescript":
+              return `(process.env["${envVarName}"] ?? "${value.defaultEnvVarValue}")`;
+            default:
+              throw new Error(`Unsupported language: ${options?.language}`);
+          }
+        }
+
+        switch (options?.language) {
+          case "python":
+            return `os.environ.get("${envVarName}")`;
+          case "typescript":
+            return `process.env["${envVarName}"]`;
+          default:
+            throw new Error(`Unsupported language: ${options?.language}`);
+        }
+      },
+    };
+
+    const handler = toJsonHandlers[value.valueType];
+    if (!handler) {
+      throw new Error(`Unable reach here: ${value}`);
     }
+    return handler(value);
   }
 
   /**
@@ -89,28 +192,30 @@ export namespace Value {
    */
   export function getTypes(value: Value): string[] {
     const types: string[] = [];
-    if (value.type) {
-      types.push(value.type);
-    }
-    if (value.value) {
-      if (Array.isArray(value.value)) {
-        // Tuple / dict
-        value.value.forEach((v) => {
-          if (Array.isArray(v)) {
-            // Dict
-            types.push(...getTypes(v[0]));
-            types.push(...getTypes(v[1]));
-          } else {
-            // Tuple
-            types.push(...getTypes(v));
-          }
+    switch (value.valueType) {
+      case ValueType.None:
+      case ValueType.Literal:
+      case ValueType.EnvVarAccess:
+        break;
+      case ValueType.Dict:
+        value.value.forEach(([k, v]) => {
+          types.push(...getTypes(k));
+          types.push(...getTypes(v));
         });
-      } else {
-        // Dataclass
+        break;
+      case ValueType.Tuple:
+        value.value.forEach((v) => {
+          types.push(...getTypes(v));
+        });
+        break;
+      case ValueType.DataClass:
+        types.push(value.classType);
         Object.values(value.value).forEach((v) => {
           types.push(...getTypes(v));
         });
-      }
+        break;
+      default:
+        throw new Error(`Unable reach here: ${value}`);
     }
     return types;
   }
@@ -119,8 +224,12 @@ export namespace Value {
 /**
  * This class evaluates the value of an expression node.
  *
- * For now, we're only able to evaluate the values of literal types and direct calls to data class
- * constructors. There are a couple of scenarios where we hit a brick wall:
+ * At present, we are only capable of evaluating the values pertaining to literal types, data class
+ * constructors, and environment variable accesses. We offer support for both direct invocation and
+ * variable access. However, it's crucial that the variable is assigned just once, and the value
+ * should be directly assigned, not via tuple assignment or accompanied with type annotations.
+ *
+ * There are a couple of scenarios where we hit a brick wall:
  *
  *   1. Values that could change on the fly — think of those unpredictable elements like the output
  *      from a random function or a timestamp. We just can't evaluate their values during static
@@ -142,12 +251,21 @@ export class ValueEvaluator {
   constructor(private readonly typeEvaluator: TypeEvaluator) {}
 
   public getValue(valueNode: ExpressionNode): Value {
-    // If the node is a literal, we can directly return the value.
     switch (valueNode.nodeType) {
       case ParseNodeType.Number:
-        return { value: valueNode.value };
+        return { valueType: ValueType.Literal, value: valueNode.value };
       case ParseNodeType.String:
-        return { value: valueNode.value };
+        return { valueType: ValueType.Literal, value: valueNode.value };
+      case ParseNodeType.Name:
+        return this.evaluateValueForVariable(valueNode);
+      case ParseNodeType.Call:
+        return this.evaluateValueForCall(valueNode);
+      case ParseNodeType.Index:
+        return this.evaluateValueForIndex(valueNode);
+      case ParseNodeType.Tuple:
+        return this.evaluateValueForTuple(valueNode);
+      case ParseNodeType.Dictionary:
+        return this.evaluateValueForDict(valueNode);
     }
 
     // Currently, we only support the variable of literal type. So, we can get the literal value
@@ -164,18 +282,18 @@ export class ValueEvaluator {
       );
     }
 
-    return this.evaluateValue(valueType, valueNode);
+    return this.evaluateValueByClassType(valueType, valueNode);
   }
 
-  private evaluateValue(type: ClassType, valueNode?: ExpressionNode): Value {
+  private evaluateValueByClassType(type: ClassType, valueNode: ExpressionNode): Value {
     const typeFullName = type.details.fullName;
 
     if (ClassType.isBuiltIn(type, "NoneType")) {
-      return { type: typeFullName };
+      return { valueType: ValueType.None };
     }
 
     if (ClassType.isBuiltIn(type)) {
-      return this.evaluateValueForBuiltin(type, valueNode);
+      return this.evaluateValueForBuiltin(type);
     }
 
     if (ClassType.isDataClass(type) && valueNode) {
@@ -187,7 +305,7 @@ export class ValueEvaluator {
     );
   }
 
-  private evaluateValueForBuiltin(type: ClassType, valueNode?: ExpressionNode): Value {
+  private evaluateValueForBuiltin(type: ClassType): Value {
     const typeFullName = type.details.fullName;
 
     let finalValue: Value | undefined;
@@ -196,20 +314,14 @@ export class ValueEvaluator {
       case "builtins.int":
       case "builtins.str":
         if (type.literalValue === undefined) {
-          // This is a builtin type, but not a literal type.
+          // This is a builtin type, but cannot determine the literal value.
           throw new Error(
             `Currently, we only support bool, int, and str literals as arguments. The '${typeFullName}' is a builtin type, but not a literal type.`
           );
         }
-        finalValue = { value: type.literalValue };
+        finalValue = { valueType: ValueType.Literal, value: type.literalValue };
         break;
 
-      case "builtins.tuple":
-        finalValue = this.evaluateValueForTuple(type, valueNode);
-        break;
-      case "builtins.dict":
-        finalValue = this.evaluateValueForDict(type, valueNode);
-        break;
       case "builtins.float":
       case "builtins.bytearray":
       case "builtins.bytes":
@@ -228,50 +340,31 @@ export class ValueEvaluator {
    * the value of each child expression in the tuple. If it's a tuple variable, we'll attempt to
    * evaluate its value based on its type.
    */
-  private evaluateValueForTuple(type: ClassType, valueNode?: ExpressionNode): Value {
+  private evaluateValueForTuple(valueNode: TupleNode): Value {
     const values: Value[] = [];
-    if (valueNode && valueNode.nodeType === ParseNodeType.Tuple) {
+    if (valueNode.nodeType === ParseNodeType.Tuple) {
       // The expression node is a tuple construction expression.
       valueNode.expressions.forEach((expression) => {
         values.push(this.getValue(expression));
       });
-    } else {
-      // The expression node is a variable of tuple type.
-      const tupleTypeArguments = type.tupleTypeArguments!;
-      tupleTypeArguments.forEach((type) => {
-        if (type.type.category !== TypeCategory.Class) {
-          throw new Error(`We don't support the type '${TypeUtils.getTypeName(type.type)}' yet.`);
-        }
-
-        // Here, we have no way to access the expression node corresponding to the `type.type`,
-        // because the argument `valueNode` is a tuple variable, not the tuple construction
-        // expression.
-        values.push(this.evaluateValue(type.type));
-      });
     }
-    return { type: type.details.fullName, value: values };
+    return { valueType: ValueType.Tuple, value: values };
   }
 
   /**
    * For the dict type, if the expression node is a dict construction expression, we'll evaluate the
    * value of each key-value pair in the dict. If it's a dict variable, we'll throw an error.
    */
-  private evaluateValueForDict(type: ClassType, valueNode?: ExpressionNode): Value {
+  private evaluateValueForDict(valueNode: DictionaryNode): Value {
     if (valueNode === undefined) {
       throw new Error(`Evaluation of the dict type without the expression node is not supported.`);
     }
 
-    if (valueNode.nodeType !== ParseNodeType.Dictionary) {
-      throw new Error(
-        `We only support constructing dictionaries using the expression, not variables yet.`
-      );
-    }
-
-    const values: ValuePair[] = [];
+    const values: [Value, Value][] = [];
     valueNode.entries.forEach((entry) => {
       if (entry.nodeType !== ParseNodeType.DictionaryKeyEntry) {
         throw new Error(
-          `We don't support the type '${type.details.fullName}' as dictionary key yet.`
+          `We only support the dictionary key-value pair in the dictionary construction expression.`
         );
       }
 
@@ -280,7 +373,7 @@ export class ValueEvaluator {
       values.push([key, value]);
     });
 
-    return { type: type.details.fullName, value: values };
+    return { valueType: ValueType.Dict, value: values };
   }
 
   /**
@@ -321,6 +414,122 @@ export class ValueEvaluator {
       values[name] = this.getValue(arg.valueExpression);
     });
 
-    return { type: type.details.fullName, value: values };
+    return { valueType: ValueType.DataClass, classType: type.details.fullName, value: values };
+  }
+
+  private evaluateValueForVariable(valueNode: NameNode): Value {
+    // First, we need to get the declaration of the variable.
+    const decls = this.typeEvaluator.getDeclarationsForNameNode(valueNode);
+    if (decls === undefined || decls?.length > 1) {
+      // If this variable is not declared, it's impossible to assess its value. If multiple
+      // declarations exist, we can't decide which one to utilize.
+      throw new Error("The variable must be declared exactly once.");
+    }
+
+    if (decls[0].node.parent?.nodeType !== ParseNodeType.Assignment) {
+      // If the variable is not directly assigned a value, we can't evaluate its value yet.
+      throw new Error(
+        `Variable '${valueNode.value}' must be assigned a value directly. We only support the simplest assignment statement, the tuple assignment or other statements are not supported yet.`
+      );
+    }
+
+    const rightExpression = decls[0].node.parent.rightExpression;
+    return this.getValue(rightExpression);
+  }
+
+  private evaluateValueForCall(valueNode: CallNode): Value {
+    // Extract the environment variable name and its default value from the expression node.
+    const extractEnvVarInfo = (argExpression: CallNode) => {
+      // The environment variable access is in the form of a function call, like
+      // `os.environ.get("key")`.
+      const argNodes = argExpression.arguments;
+      if (argNodes.length !== 1 && argNodes.length !== 2) {
+        throw new Error("The `os.environ.get` function should have one or two arguments.");
+      }
+      const envNameNode = argNodes[0];
+      const defaultEnvVarValueNode = argNodes[1];
+
+      // We try to get the text of the index using the value evaluator.
+      const envNameValue = this.getValue(envNameNode.valueExpression);
+      if (envNameValue.valueType !== ValueType.Literal || typeof envNameValue.value !== "string") {
+        // Only when a value's type is undefined can we infer that it's a primitive type. Hence,
+        // if a type is specified, it suggests that the value isn't a literal, and we can't
+        // ascertain its react value.
+        throw new Error("The environment variable name must be a string literal.");
+      }
+      const envVarName = envNameValue.value;
+
+      let defaultEnvVarValue: string | undefined;
+      if (defaultEnvVarValueNode) {
+        const envVarValue = this.getValue(defaultEnvVarValueNode.valueExpression);
+        if (envVarValue.valueType !== ValueType.Literal || typeof envVarValue.value !== "string") {
+          throw new Error("The default environment variable value must be a string literal.");
+        }
+        defaultEnvVarValue = envVarValue.value;
+      }
+
+      return {
+        envVarName: envVarName,
+        defaultEnvVarValue: defaultEnvVarValue,
+      };
+    };
+
+    if (TypeUtils.isEnvVarAccess(valueNode, this.typeEvaluator)) {
+      // If this variable receives the value of an environment variable, we need to extract the name
+      // of the environment variable, and its default value.
+      return {
+        valueType: ValueType.EnvVarAccess,
+        ...extractEnvVarInfo(valueNode),
+      };
+    }
+
+    const valueType = this.typeEvaluator.getType(valueNode);
+    if (valueType && valueType.category === TypeCategory.Class) {
+      // This might be a call to a data class constructor
+      return this.evaluateValueByClassType(valueType, valueNode);
+    }
+
+    throw new Error(
+      `Currently, we only support for accessing environment variables and constructing dataclass instances during function calls.`
+    );
+  }
+
+  private evaluateValueForIndex(valueNode: IndexNode): Value {
+    // Extract the environment variable name and its default value from the expression node.
+    const extractEnvVarInfo = (argExpression: IndexNode) => {
+      // The environment variable access is in the form of an index, like `os.environ["key"]`.
+      const indexItems = argExpression.items;
+      if (indexItems.length !== 1) {
+        throw new Error("The index of the `os.environ` access should have only one item.");
+      }
+      const envNameNode = indexItems[0];
+
+      // We try to get the text of the index using the value evaluator.
+      const envNameValue = this.getValue(envNameNode.valueExpression);
+      if (envNameValue.valueType !== ValueType.Literal || typeof envNameValue.value !== "string") {
+        // Only when a value's type is undefined can we infer that it's a primitive type. Hence,
+        // if a type is specified, it suggests that the value isn't a literal, and we can't
+        // ascertain its react value.
+        throw new Error("The environment variable name must be a string literal.");
+      }
+      const envVarName = envNameValue.value;
+
+      return { envVarName: envVarName };
+    };
+
+    if (TypeUtils.isEnvVarAccess(valueNode, this.typeEvaluator)) {
+      // If this variable receives the value of an environment variable, we need to extract the name
+      // of the environment variable, and its default value.
+      return {
+        valueType: ValueType.EnvVarAccess,
+        ...extractEnvVarInfo(valueNode),
+      };
+    }
+
+    console.log(valueNode);
+
+    throw new Error(
+      `Currently, we only support for accessing environment variables using the index.`
+    );
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- deducler
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

This update enhances the deducer module by allowing environment variables and variables to be passed to resource constructors and infra API arguments. Specifically, it now supports:
- Direct literal values (e.g., `1`, `true`, `"hello"`).
- Direct dataclass constructors (e.g., `Model(name="hello")` where `Model` is a dataclass).
- Direct access to environment variables (e.g., `os.environ["key"]`, `os.environ.get("key", "default")`).
- Variables (e.g., `var1`, `var2`), with the requirement that they are defined exactly once and assigned with the supported value types.
- Tuples or dicts containing the supported types of values.
<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
