### PR TITLE
feat: enable runtime access to locally defined env vars

### DIFF
--- a/.changeset/tame-dolphins-cough.md
+++ b/.changeset/tame-dolphins-cough.md
@@ -1,0 +1,12 @@
+---
+"@plutolang/pyright-deducer": patch
+"@plutolang/static-generator": patch
+"@plutolang/pluto-infra": patch
+"@plutolang/base": patch
+---
+
+feat: enable runtime access to locally defined env vars
+
+Previously, environment variables were only accessible through the resource constructor and infrastructure APIs. This commit enables client APIs to access these variables.
+
+During function argument extraction by the deducer from the resource constructor or infrastructure APIs, all accessed environment variables within the compute closure are recorded. These variables are then passed to the architecture reference. Subsequently, the generator declares these environment variables for each closure variable in the IaC code. When the adapter runs the IaC code, it sets up the environment variables for the built function instance, such as AWS Lambda instances. The procedure of setting up these environment variables is written in the infrastructure SDK.

--- a/components/deducers/python-pyright/src/index.ts
+++ b/components/deducers/python-pyright/src/index.ts
@@ -530,8 +530,9 @@ function extractAndStoreClosure(
   fs.ensureFileSync(closureFile);
   fs.writeFileSync(closureFile, closureText);
 
+  const accessedEnvVars = CodeSegment.getAccessedEnvVars(codeSegment);
   return {
-    closure: new arch.Closure(closureId, path.dirname(closureFile)),
+    closure: new arch.Closure(closureId, path.dirname(closureFile), accessedEnvVars),
     codeSegment,
   };
 }

--- a/components/generators/static/src/generator.ts
+++ b/components/generators/static/src/generator.ts
@@ -154,6 +154,7 @@ const ${closure.id} = createClosure(${closure.id}_func, {
   dirpath: "${dirpath}",
   exportName: "${exportName}",
   dependencies: [${dependenciesString}],
+  accessedEnvVars: [${closure.envVars.map((envVar) => `"${envVar}"`).join(", ")}],
 });
 `;
   }

--- a/docs/documentation/library/secret.en.mdx
+++ b/docs/documentation/library/secret.en.mdx
@@ -79,3 +79,7 @@ Function(returnSecret);
 </Tab>
 
 </Tabs>
+
+<Callout>
+It's important to mention that when the `Secret` resource is utilized by runtime functions like `Function`, the local environment variables that the `Secret` relies on will be automatically incorporated into the environment variable configuration of these runtime functions.
+</Callout>

--- a/docs/documentation/library/secret.zh-CN.mdx
+++ b/docs/documentation/library/secret.zh-CN.mdx
@@ -79,3 +79,7 @@ Function(returnSecret);
 </Tab>
 
 </Tabs>
+
+<Callout>
+需要注意的是，当 `Secret` 资源被运行时函数（如 `Function`）引用时，`Secret` 依赖的本地环境变量会被自动注入到运行时函数的环境变量中。
+</Callout>

--- a/packages/base/arch/closure.ts
+++ b/packages/base/arch/closure.ts
@@ -3,7 +3,8 @@ export class Closure {
 
   constructor(
     public readonly id: string,
-    public readonly path: string
+    public readonly path: string,
+    public readonly envVars: string[] = []
   ) {}
 }
 

--- a/packages/base/closure/create-closure.ts
+++ b/packages/base/closure/create-closure.ts
@@ -7,10 +7,9 @@ export function createClosure<T extends AnyFunction>(
   options?: CreateClosureOptions
 ): ComputeClosure<T> {
   const newClosure: ComputeClosure<T> = Object.assign(fn, {
+    ...options,
     dirpath: options?.dirpath ?? "inline",
     exportName: options?.exportName ?? "default",
-    placeholder: options?.placeholder,
-    dependencies: options?.dependencies,
   });
 
   if (isComputeClosure(newClosure)) {
@@ -29,6 +28,7 @@ export function wrapClosure<T extends AnyFunction, K extends AnyFunction>(
     exportName: options?.exportName ?? "default",
     placeholder: options?.placeholder,
     dependencies: closure.dependencies?.concat(options?.dependencies ?? []),
+    accessedEnvVars: closure.accessedEnvVars?.concat(options?.accessedEnvVars ?? []),
     innerClosure: closure,
   });
 

--- a/packages/base/closure/types.ts
+++ b/packages/base/closure/types.ts
@@ -38,6 +38,9 @@ export interface ComputeClosure<T extends AnyFunction> {
 
   // The client api and property dependencies of the compute closure.
   dependencies?: Dependency[];
+
+  // The environment variables accessed within the compute closure.
+  accessedEnvVars?: string[];
 }
 
 export function isComputeClosure<T extends AnyFunction>(obj: any): obj is ComputeClosure<T> {

--- a/packages/pluto-infra/src/alicloud/function.fc.ts
+++ b/packages/pluto-infra/src/alicloud/function.fc.ts
@@ -80,6 +80,9 @@ export class FCInstance extends pulumi.ComponentResource implements IResourceInf
         const envName = createEnvNameForProperty(dep.resourceObject.id, dep.operation);
         envs[envName] = (dep.resourceObject as any)[dep.operation]();
       });
+    closure.accessedEnvVars?.forEach((envVar) => {
+      envs[envVar] = process.env[envVar];
+    });
 
     // Serialize the closure with its dependencies to a directory.
     const workdir = path.join(os.tmpdir(), `pluto`, `${this.id}_${Date.now()}`);

--- a/packages/pluto-infra/src/k8s/function.service.ts
+++ b/packages/pluto-infra/src/k8s/function.service.ts
@@ -95,6 +95,15 @@ export class KnativeService
         envs.push({ name: key, value: options.envs[key] });
       }
     }
+    closure.dependencies
+      ?.filter((dep) => dep.type === "property")
+      .forEach((dep) => {
+        const envName = createEnvNameForProperty(dep.resourceObject.id, dep.operation);
+        envs.push({ name: envName, value: (dep.resourceObject as any)[dep.operation]() });
+      });
+    closure.accessedEnvVars?.forEach((envVar) => {
+      envs.push({ name: envVar, value: process.env[envVar] ?? "" });
+    });
 
     // Create the knative service.
     const kservice = this.createKnativeService(image, envs);


### PR DESCRIPTION
Previously, environment variables were only accessible through the resource constructor and infrastructure APIs. This commit enables client APIs to access these variables.

During function argument extraction by the deducer from the resource constructor or infrastructure APIs, all accessed environment variables within the compute closure are recorded. These variables are then passed to the architecture reference. Subsequently, the generator declares these environment variables for each closure variable in the IaC code. When the adapter runs the IaC code, it sets up the environment variables for the built function instance, such as AWS Lambda instances. The procedure of setting up these environment variables is written in the infrastructure SDK.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
- Generator
- Base SDK
- Infra SDK

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
