### PR TITLE
fix(deducer): ensure consistent parameter order between Python and TypeScript

### DIFF
--- a/.changeset/heavy-singers-speak.md
+++ b/.changeset/heavy-singers-speak.md
@@ -1,0 +1,7 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+fix(deducer): ensure consistent parameter order between Python and TypeScript
+
+The use of a named parameter list in the Python deducer code led to inconsistencies with the TypeScript IaC code parameter order. This change aligns the parameter orders across both languages to ensure consistency and avoid potential confusion or errors due to mismatched parameters.

--- a/components/deducers/python-pyright/src/test/deducer.test.ts
+++ b/components/deducers/python-pyright/src/test/deducer.test.ts
@@ -96,6 +96,25 @@ func_with_options = Function(lambda x: x, name="option", options=FunctionOptions
   clean();
 });
 
+test("should correctly deduce the arguments in the sequence of the function signature parameters.", async () => {
+  const code = `
+from pluto_client import Website, WebsiteOptions
+
+website = Website("./web", opts=WebsiteOptions(platform="Vercel"))
+`;
+
+  const { archRef, clean } = await getArchRefForInline(code);
+
+  expect(archRef.resources).toHaveLength(1);
+
+  const resource = archRef.resources[0];
+  expect(resource).toBeDefined();
+  expect(resource.parameters).toHaveLength(3);
+  expect(resource.parameters[1].value).toEqual("undefined");
+
+  clean();
+});
+
 async function getArchRefForInline(code: string, filename: string = "tmp.py") {
   const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "pyright-deducer-"));
   const tmpfile = path.join(tmpdir, filename);


### PR DESCRIPTION


<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
The use of a named parameter list in the Python deducer code led to inconsistencies with the TypeScript IaC code parameter order. This change aligns the parameter orders across both languages to ensure consistency and avoid potential confusion or errors due to mismatched parameters.
#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
