### PR TITLE
fix(ci): prevent modification of dotfiles during release

### DIFF
--- a/.changeset/neat-pugs-play.md
+++ b/.changeset/neat-pugs-play.md
@@ -1,0 +1,11 @@
+---
+"@plutolang/cli": patch
+---
+
+fix(ci): prevent modification of dotfiles during release
+
+The dotfiles necessary for creating new Pluto app projects are stored without the leading dot and are modified when the CLI package is installed.
+
+Due to the repository being a monorepo managed by pnpm, executing `pnpm install` triggers the postinstall script, altering the dotfiles. Consequently, the released package fails to include the dotfiles.
+
+This commit resolves the issue by bypassing the postinstall script during CI package installation when the `RELEASE` environment variable is present.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions: {} #reset
+env:
+  CI: true
+  RELEASE: true
 jobs:
   release:
     # prevent this action from running on forks

--- a/apps/cli/scripts/postinstall.sh
+++ b/apps/cli/scripts/postinstall.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# If this is a release build and we are in CI, skip this script to avoid modifying the source code
+if [ "$RELEASE" = "true" ] && [ "$CI" = "true" ]; then
+    echo "Skipping postinstall.sh"
+    exit 0
+fi
+
 languages=("python" "typescript")
 files=("gitignore" "env" "env.local")
 


### PR DESCRIPTION
The dotfiles necessary for creating new Pluto app projects are stored without the leading dot and are modified when the CLI package is installed.

Due to the repository being a monorepo managed by pnpm, executing `pnpm install` triggers the postinstall script, altering the dotfiles. Consequently, the released package fails to include the dotfiles.

This commit resolves the issue by bypassing the postinstall script during CI package installation when the `RELEASE` environment variable is present.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- cli
- ci
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
