### PR TITLE
fix(adapter): correct parsing error for complex JSON values

### DIFF
--- a/.changeset/beige-cars-invent.md
+++ b/.changeset/beige-cars-invent.md
@@ -1,0 +1,7 @@
+---
+"@plutolang/simulator-adapter": patch
+---
+
+fix(adapter): correct parsing error for complex JSON values
+
+The current implementation uses `eval` to parse values that may include `process.env`. However, `eval` throws errors when parsing complex JSON structures. This commit resolves the issue by creating a string that assigns the value to a variable and subsequently returns the variable, which `eval` can then parse without errors.

--- a/components/adapters/simulator/src/simulator.ts
+++ b/components/adapters/simulator/src/simulator.ts
@@ -78,7 +78,7 @@ export class Simulator {
     const dotPos = resourceTypeFqn.lastIndexOf(".");
     const pkgName = resourceTypeFqn.substring(0, dotPos);
     const resourceType = resourceTypeFqn.substring(dotPos + 1);
-    // TODO: check if the package exists
+    // TODO: check if the package exists, and import from user project
     const infraPkg = (await import(`${pkgName}-infra`)) as any;
     const resourceInfraClass = infraPkg[resourceType];
     if (!resourceInfraClass) {
@@ -90,7 +90,8 @@ export class Simulator {
     const args = new Array(resource.arguments.length);
     resource.arguments.forEach((param) => {
       if (param.type === "text") {
-        args[param.index] = param.value === "undefined" ? undefined : eval(param.value);
+        args[param.index] =
+          param.value === "undefined" ? undefined : eval(`const v = ${param.value}; v`);
       } else if (param.type === "closure") {
         args[param.index] = this.closures.get(param.closureId);
       } else if (param.type === "capturedProperty") {


### PR DESCRIPTION
The current implementation uses `eval` to parse values that may include `process.env`. However, `eval` throws errors when parsing complex JSON structures. This commit resolves the issue by creating a string that assigns the value to a variable and subsequently returns the variable, which `eval` can then parse without errors.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Simulator Adapter
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
