### PR TITLE
feat(deducer): add support for custom runtime adapter

### DIFF
--- a/.changeset/unlucky-zoos-cross.md
+++ b/.changeset/unlucky-zoos-cross.md
@@ -1,0 +1,12 @@
+---
+"@plutolang/pyright-deducer": patch
+"@plutolang/simulator-adapter": patch
+"@plutolang/base": patch
+"@plutolang/cli": patch
+---
+
+feat(deducer): add support for custom runtime adapter
+
+Add functionality to handle a custom adapter in the stack configuration.
+
+When the 'provision type' option is set to 'Custom', users are now prompted to enter the name of their adapter package. Once supplied, it is included in the project's configuration, enabling the use of a bespoke adapter.

--- a/apps/cli/src/builder/project.ts
+++ b/apps/cli/src/builder/project.ts
@@ -44,9 +44,19 @@ export async function createProject(args: CreateProjectArgs): Promise<config.Pro
     provisionType: args.provisionType,
   });
 
+  let customAdapter: string | undefined;
+  if (sta.provisionType === ProvisionType.Custom) {
+    customAdapter = await input({
+      message: "Please provide the adapter package name for the custom stack",
+    }).catch(handleIquirerError);
+  }
+
   const projectRoot = resolve(args.rootpath ?? `./${args.name}`);
   const proj = new config.Project(args.name!, projectRoot, args.language!);
   proj.addStack(sta);
   proj.current = sta.name;
+
+  customAdapter ? (proj.configs["adapter"] = customAdapter) : null;
+
   return proj;
 }

--- a/apps/cli/src/builder/stack.ts
+++ b/apps/cli/src/builder/stack.ts
@@ -35,13 +35,12 @@ export async function createStack(args: CreateStackArgs): Promise<config.Stack> 
           value: PlatformType.AliCloud,
         },
         {
-          name: "GCP",
-          value: PlatformType.GCP,
-          disabled: "(Coming soon)",
-        },
-        {
           name: "Custom",
           value: PlatformType.Custom,
+        },
+        {
+          name: "GCP",
+          value: PlatformType.GCP,
           disabled: "(Coming soon)",
         },
       ],
@@ -57,6 +56,10 @@ export async function createStack(args: CreateStackArgs): Promise<config.Stack> 
           value: ProvisionType.Pulumi,
         },
         {
+          name: "Custom",
+          value: ProvisionType.Custom,
+        },
+        {
           name: "Terraform",
           value: ProvisionType.Terraform,
           disabled: "(Coming soon)",
@@ -64,5 +67,6 @@ export async function createStack(args: CreateStackArgs): Promise<config.Stack> 
       ],
     }).catch(handleIquirerError));
 
-  return new config.Stack(args.name!, args.platformType!, args.provisionType!);
+  const stack = new config.Stack(args.name!, args.platformType!, args.provisionType!);
+  return stack;
 }

--- a/components/adapters/simulator/src/simulator.ts
+++ b/components/adapters/simulator/src/simulator.ts
@@ -79,7 +79,7 @@ export class Simulator {
     const pkgName = resourceTypeFqn.substring(0, dotPos);
     const resourceType = resourceTypeFqn.substring(dotPos + 1);
     // TODO: check if the package exists, and import from user project
-    const infraPkg = (await import(`${pkgName}-infra`)) as any;
+    const infraPkg = (await import(resolvePkg(`${pkgName}-infra`))) as any;
     const resourceInfraClass = infraPkg[resourceType];
     if (!resourceInfraClass) {
       throw new Error(
@@ -322,5 +322,14 @@ function isValidJson(str: string): boolean {
     return true;
   } catch (e) {
     return false;
+  }
+}
+
+function resolvePkg(pkgName: string): string {
+  try {
+    const pkgPath = require.resolve(pkgName, { paths: [process.cwd(), __dirname] });
+    return pkgPath;
+  } catch (e) {
+    throw new Error(`Cannot find package ${pkgName}`);
   }
 }

--- a/packages/base/core/adapter.ts
+++ b/packages/base/core/adapter.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { LanguageType } from "../language";
 import { Architecture } from "../arch";
 import { BaseComponent, BasicArgs } from "./base-component";
@@ -93,4 +94,18 @@ export abstract class Adapter extends BaseComponent {
   public abstract state(): Promise<StateResult>;
   public abstract deploy(options?: DeployOptions): Promise<DeployResult>;
   public abstract destroy(options?: DestroyOptions): Promise<void>;
+}
+
+export function isAdapter(obj: any): obj is Adapter {
+  // Check if obj is not null or undefined
+  if (!obj) return false;
+
+  // Check for characteristic properties of Adapter
+  const methods = ["state", "deploy", "destroy"];
+  for (const method of methods) {
+    if (!_.isFunction(obj[method])) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
Add functionality to handle a custom adapter in the stack configuration.

When the 'provision type' option is set to 'Custom', users are now prompted to enter the name of their adapter package. Once supplied, it is included in the project's configuration, enabling the use of a bespoke adapter.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- CLI
- Pyright Deducer
- Simulator Adapter
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
