### PR TITLE
fix(deducer): resolve deducer malfunction with imports in function body

### DIFF
--- a/.changeset/slimy-pots-wait.md
+++ b/.changeset/slimy-pots-wait.md
@@ -1,0 +1,7 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+fix(deducer): resolve deducer malfunction with imports in function body
+
+The deducer fails to operate correctly when encountering import statements inside function bodies, attempting to retrieve module symbols from these local scope imports. Since global scope is required for symbol resolution and these imports don't need extraction, the solution is to bypass import statements during the extraction process.

--- a/components/deducers/python-pyright/src/code-extractor.ts
+++ b/components/deducers/python-pyright/src/code-extractor.ts
@@ -965,6 +965,16 @@ class OutsideSymbolFinder extends ParseTreeWalker {
     return Array.from(this._envVarNames);
   }
 
+  public override visitImport(): boolean {
+    // Ignore the import statement. We don't need to extract the imported modules.
+    return false;
+  }
+
+  public override visitImportFrom(): boolean {
+    // Ignore the import-from statement. We don't need to extract the imported modules.
+    return false;
+  }
+
   public override visitName(node: NameNode): boolean {
     if (node !== this.rootNode && !this.shouldIgnore(node)) {
       const symbol = this.typeEvaluator.lookUpSymbolRecursive(node, node.value, false);


### PR DESCRIPTION
The deducer fails to operate correctly when encountering import statements inside function bodies, attempting to retrieve module symbols from these local scope imports. Since global scope is required for symbol resolution and these imports don't need extraction, the solution is to bypass import statements during the extraction process.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
