### PR TITLE
fix(deducer): avoid retrieving declarations for non-infrastructure ca…

### DIFF
--- a/.changeset/wild-planets-report.md
+++ b/.changeset/wild-planets-report.md
@@ -1,0 +1,7 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+fix(deducer): avoid retrieving declarations for non-infrastructure call nodes
+
+Previously, the deducer attempted to retrieve all call node declarations and match them against custom infrastructure functions. This method was flawed as functions with multiple declarations caused the deducer to fail. To address this, we now first verify that a call node pertains to a custom infrastructure function by comparing function names. Only then do we fetch the call node's declaration, effectively bypassing the collection of extraneous call node declarations.

--- a/components/deducers/python-pyright/src/custom-infra-fn/custom-infra-fn-types.ts
+++ b/components/deducers/python-pyright/src/custom-infra-fn/custom-infra-fn-types.ts
@@ -1,9 +1,9 @@
 import { Scope } from "pyright-internal/dist/analyzer/scope";
-import { ParseNode } from "pyright-internal/dist/parser/parseNodes";
+import { FunctionNode } from "pyright-internal/dist/parser/parseNodes";
 import { SourceFile } from "pyright-internal/dist/analyzer/sourceFile";
 
 export interface CustomInfraFn {
-  readonly topNode: ParseNode;
+  readonly topNode: FunctionNode;
   readonly hierarchy: Scope[];
   readonly sourceFile: SourceFile;
 }


### PR DESCRIPTION


Previously, the deducer attempted to retrieve all call node declarations and match them against custom infrastructure functions. This method was flawed as functions with multiple declarations caused the deducer to fail. To address this, we now first verify that a call node pertains to a custom infrastructure function by comparing function names. Only then do we fetch the call node's declaration, effectively bypassing the collection of extraneous call node declarations.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
