### PR TITLE
fix(deducer): correct package directory resolution and METADATA parsing

### DIFF
--- a/.changeset/itchy-countries-tap.md
+++ b/.changeset/itchy-countries-tap.md
@@ -1,0 +1,10 @@
+---
+"@plutolang/pyright-deducer": patch
+---
+
+fix(deducer): correct package directory resolution and METADATA parsing
+
+This commit addresses two separate issues identified in the deducer:
+
+- The deducer incorrectly searched for distribution information within the stub type directory, which lacks the required dist info. The resolution has been updated to check for the presence of `nonStubImportResult` within the `ImportResult`. If present, it is now utilized to determine the correct package directory.
+- The parsing of the `dist-info/METADATA` file was flawed due to the possibility of encountering multiple `Name` lines. The parser has been adjusted to only consider lines that begin with `Name:` and are not preceded by any spaces.


### PR DESCRIPTION
This commit addresses two separate issues identified in the deducer:
- The deducer incorrectly searched for distribution information within the stub type directory, which lacks the required dist info. The resolution has been updated to check for the presence of `nonStubImportResult` within the `ImportResult`. If present, it is now utilized to determine the correct package directory.
- The parsing of the `dist-info/METADATA` file was flawed due to the possibility of encountering multiple `Name` lines. The parser has been adjusted to only consider lines that begin with `Name:` and are not preceded by any spaces.

<!-- Thank you for contributing to Pluto!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. -->
- Pyright Deducer
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [x] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
